### PR TITLE
Fix: Custom headers in Tornado Client

### DIFF
--- a/jsonrpcclient/tornado_client.py
+++ b/jsonrpcclient/tornado_client.py
@@ -55,7 +55,7 @@ class TornadoClient(Client):
         :return: The response (a string for requests, None for notifications).
         """
         headers = dict(self._DEFAULT_HEADERS)
-        headers.update(kwargs.get('headers', {}))
+        headers.update(kwargs.pop('headers', {}))
 
         future = Future()
         self.http_client.fetch(

--- a/test/test_tornado_client.py
+++ b/test/test_tornado_client.py
@@ -53,3 +53,11 @@ class TestTornadoClient(testing.AsyncHTTPTestCase):
         with self.assertRaises(httpclient.HTTPError) as ctx:
             yield testee.fail(code=500)
         self.assertEqual('HTTP 500: Internal Server Error', str(ctx.exception))
+
+    @testing.gen_test
+    def test_custom_headers(self):
+        testee = TornadoClient(self.get_url('/echo'))
+        response = yield testee.send(
+            Request('some_method', 1, [2], {'3': 4, '5': True, '6': None}),
+            headers={'foo': 'bar'})
+        self.assertEqual([1, [2], {'3': 4, '6': None, '5': True}], response)


### PR DESCRIPTION
Fixes

```
TypeError: fetch() got multiple values for keyword argument 'headers'
```

When using `get`, `headers` stays in `kwargs`, resulting in duplicate values.