### PR TITLE
Ignore empty error bodies

### DIFF
--- a/jsonrpcclient/client.py
+++ b/jsonrpcclient/client.py
@@ -107,7 +107,7 @@ class Client(with_metaclass(ABCMeta, object)):
                 return response
             else:
                 # If the response was "error", raise to ensure it's handled
-                if 'error' in response:
+                if 'error' in response and response['error'] is not None:
                     raise exceptions.ReceivedErrorResponse(
                         response['error'].get('code'),
                         response['error'].get('message'),


### PR DESCRIPTION
I'm not sure what the JSON-RPC spec says about how error information should be sent from the RPC server back to the requester but I have run into this issue using the `bitcoind` RPC server. That particular server will send back an `error` key in the response body but it will have a value of `null` which causes this response processor to fail.