### PR TITLE
Add trim_log_values option to config to abbreviate long strings and lists

### DIFF
--- a/jsonrpcclient/client.py
+++ b/jsonrpcclient/client.py
@@ -36,7 +36,7 @@ class Client(with_metaclass(ABCMeta, object)):
         #: Holds the server address
         self.endpoint = endpoint
 
-    def log_(self, message, extra, log, level, fmt):
+    def log_(self, message, extra, log, level, fmt, trim):
         """Log a request or response"""
         if extra is None:
             extra = {}
@@ -45,9 +45,9 @@ class Client(with_metaclass(ABCMeta, object)):
         # Clean up the message for logging
         if isinstance(message, basestring):
             message = message.replace("\n", "").replace("  ", " ").replace("{ ", "{")
-        log_(log, level, message, extra=extra, fmt=fmt)
+        log_(log, level, message, extra=extra, fmt=fmt, trim=trim)
 
-    def log_request(self, request, extra=None, fmt=None):
+    def log_request(self, request, extra=None, fmt=None, trim=False):
         """
         Log a request.
 
@@ -58,9 +58,9 @@ class Client(with_metaclass(ABCMeta, object)):
         """
         if not fmt:
             fmt = "--> %(message)s"
-        self.log_(request, extra, self.request_log, "info", fmt)
+        self.log_(request, extra, self.request_log, "info", fmt, trim)
 
-    def log_response(self, response, extra=None, fmt=None):
+    def log_response(self, response, extra=None, fmt=None, trim=False):
         """
         Log a response.
 
@@ -72,7 +72,7 @@ class Client(with_metaclass(ABCMeta, object)):
         """
         if not fmt:
             fmt = "<-- %(message)s"
-        self.log_(response, extra, self.response_log, "info", fmt)
+        self.log_(response, extra, self.response_log, "info", fmt, trim)
 
     def prepare_request(self, request, **kwargs):
         """
@@ -92,7 +92,7 @@ class Client(with_metaclass(ABCMeta, object)):
         """
         if response:
             # Log the response before processing it
-            self.log_response(response, log_extra, log_format)
+            self.log_response(response, log_extra, log_format, config.trim_log_values)
             # If it's a json string, parse to object
             if isinstance(response, basestring):
                 try:
@@ -167,7 +167,7 @@ class Client(with_metaclass(ABCMeta, object)):
         # set the extra details to include in the log entry
         self.prepare_request(request)
         # Log the request
-        self.log_request(request, request.log_extra, request.log_format)
+        self.log_request(request, request.log_extra, request.log_format, config.trim_log_values)
         # Call abstract method to transport the message, returning either the
         # processed response, or a future which promises to process eventually
         return self.send_message(request, **kwargs)

--- a/jsonrpcclient/config.py
+++ b/jsonrpcclient/config.py
@@ -13,3 +13,6 @@ ids = "decimal"
 #: Validate responses against the JSON-RPC schema. Disable to speed up
 #: processing.
 validate = True
+
+#: Log abbreviated versions of requests and responses
+trim_log_values = False

--- a/jsonrpcclient/log.py
+++ b/jsonrpcclient/log.py
@@ -1,9 +1,14 @@
 """Logging"""
 import logging
+import json
 
 
 def configure_logger(logger, fmt):
-    """Set up a logger, if no handler has been configured for it."""
+    """
+    Set up a logger, if no handler has been configured for it.
+
+    Used by the log function below.
+    """
     if logger.level == logging.NOTSET:
         logger.setLevel(logging.INFO)
     if not logging.root.handlers and not logger.handlers:
@@ -12,8 +17,49 @@ def configure_logger(logger, fmt):
         logger.addHandler(handler)
 
 
+def _trim_string(message):
+    longest_string = 30
+
+    if len(message) > longest_string:
+        prefix_len = int(longest_string / 3)
+        suffix_len = prefix_len
+        return message[:prefix_len] + "..." + message[-suffix_len:]
+
+    return message
+
+
+def _trim_values(message_obj):
+    result = {}
+    longest_list = 30
+    for k, val in message_obj.items():
+        if isinstance(val, str):
+            result[k] = _trim_string(val)
+        elif isinstance(val, list) and len(val) > longest_list:
+            prefix_len = int(longest_list / 3)
+            suffix_len = prefix_len
+            result[k] = val[:prefix_len] + ["..."] + val[-suffix_len:]
+        elif isinstance(val, dict):
+            result[k] = _trim_values(val)
+        else:
+            result[k] = val
+    return result
+
+
+def trim_message(message):
+    try:
+        message_obj = json.loads(message)
+        return json.dumps(_trim_values(message_obj))
+    except ValueError:
+        return _trim_string(str(message))
+
+
 def log_(logger, level, message, *args, **kwargs):
-    """Configure before logging."""
+    """
+    Log a message.
+    """
     fmt = kwargs.pop("fmt", "%(message)s")
+    trim = kwargs.pop("trim", False)
+    if trim:
+        message = trim_message(message)
     configure_logger(logger, fmt)
     getattr(logger, level)(message, *args, **kwargs)


### PR DESCRIPTION
Following on from bcb/jsonrpcserver#65

Part of me thought about storing `.trim_log_values` on the PreparedRequest object, but I wasn't sure...