### PR TITLE
Configure client and convenience funcs with params

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -127,21 +127,40 @@ each request that had an `id` member.
 
 ## Configuration
 
-Import the config module to to configure, for example:
+Most public methods can take the following optional parameters:
 
+**id_generator**
+
+Specifies a generator which will be used to create the "id" part of the
+JSON-RPC request. Some built-in options are in the ids module: decimal,
+hexadecimal, random and uuid. Default is *ids.decimal()*.
+
+Example:
 ```python
-from jsonrpcclient import config
-config.validate = False
-config.ids = "hex"
+>>> from jsonrpcclient import request, ids
+>>> random_ids = ids.random()
+>>> request("http://localhost:5000", "ping", id_generator=random_ids)
+--> {"jsonrpc": "2.0", "method": "ping", "id": "9zo2a2xb"}
 ```
 
-To disable logging:
+**request_id**
 
+Specifies the "id" part of the JSON-RPC request. Default is *None*, which calls
+`next()` on the last id generator that was used.
+
+Example:
 ```python
-import logging
-logging.getLogger("jsonrpcclient.client.request").setLevel(logging.WARNING)
-logging.getLogger("jsonrpcclient.client.response").setLevel(logging.WARNING)
+>>> request("http://localhost:5000", "ping", request_id="foo")
+--> {"jsonrpc": "2.0", "method": "ping", "id": "foo"}
 ```
+
+**trim_log_values**
+
+Show abbreviated requests and responses in logs. Default is *False*.
+
+**validate_against_schema**
+
+Validate responses against the JSON-RPC schema. Default is *True*.
 
 ### Configuring the Requests library
 
@@ -177,3 +196,13 @@ client.send(req, verify=True, cert='/path/to/certificate',
 As in the Requests library, any dictionaries passed to `send` in named
 arguments will be merged with the session-level values that are set. The
 method-level parameters override session parameters.
+
+## Disable logging
+
+To disable logging:
+
+```python
+import logging
+logging.getLogger("jsonrpcclient.client.request").setLevel(logging.WARNING)
+logging.getLogger("jsonrpcclient.client.response").setLevel(logging.WARNING)
+```

--- a/jsonrpcclient/__init__.py
+++ b/jsonrpcclient/__init__.py
@@ -2,13 +2,22 @@ from .request import Request, Notification
 from .http_client import HTTPClient
 
 
-def notify(endpoint, method, *args, trim_log_values=False, validate=True, **kwargs):
+def notify(
+    endpoint,
+    method,
+    *args,
+    trim_log_values=False,
+    validate_against_schema=True,
+    **kwargs
+):
     """
     A convenience function. Instantiates and executes a HTTPClient request, then
     throws it away.
     """
     return HTTPClient(
-        endpoint, trim_log_values=trim_log_values, validate=validate
+        endpoint,
+        trim_log_values=trim_log_values,
+        validate_against_schema=validate_against_schema,
     ).notify(method, *args, **kwargs)
 
 
@@ -18,7 +27,7 @@ def request(
     *args,
     id_generator=None,
     trim_log_values=False,
-    validate=True,
+    validate_against_schema=True,
     **kwargs
 ):
     """
@@ -29,5 +38,5 @@ def request(
         endpoint,
         id_generator=id_generator,
         trim_log_values=trim_log_values,
-        validate=validate,
+        validate_against_schema=validate_against_schema,
     ).request(method, *args, **kwargs)

--- a/jsonrpcclient/__init__.py
+++ b/jsonrpcclient/__init__.py
@@ -2,17 +2,32 @@ from .request import Request, Notification
 from .http_client import HTTPClient
 
 
-def request(endpoint, method, *args, **kwargs):
+def notify(endpoint, method, *args, trim_log_values=False, validate=True, **kwargs):
     """
     A convenience function. Instantiates and executes a HTTPClient request, then
     throws it away.
     """
-    return HTTPClient(endpoint).request(method, *args, **kwargs)
+    return HTTPClient(
+        endpoint, trim_log_values=trim_log_values, validate=validate
+    ).notify(method, *args, **kwargs)
 
 
-def notify(endpoint, method, *args, **kwargs):
+def request(
+    endpoint,
+    method,
+    *args,
+    id_generator=None,
+    trim_log_values=False,
+    validate=True,
+    **kwargs
+):
     """
     A convenience function. Instantiates and executes a HTTPClient request, then
     throws it away.
     """
-    return HTTPClient(endpoint).notify(method, *args, **kwargs)
+    return HTTPClient(
+        endpoint,
+        id_generator=id_generator,
+        trim_log_values=trim_log_values,
+        validate=validate,
+    ).request(method, *args, **kwargs)

--- a/jsonrpcclient/client.py
+++ b/jsonrpcclient/client.py
@@ -33,19 +33,27 @@ class Client(with_metaclass(ABCMeta, object)):
     )
 
     def __init__(
-        self, endpoint, id_generator=None, trim_log_values=False, validate=None
+        self,
+        endpoint,
+        id_generator=None,
+        trim_log_values=False,
+        validate_against_schema=None,
     ):
         """
         :param endpoint: Holds the server address.
         :param trim_log_values: Log abbreviated versions of requests and responses
-        :param validate: Validate responses against the JSON-RPC schema.
+        :param validate_against_schema: Validate responses against the JSON-RPC schema.
         """
         self.endpoint = endpoint
         self.id_generator = id_generator
         self.trim_log_values = trim_log_values
         # The following supports the config module, which will be removed in the next
         # major release, replaced with default values in the method signature.
-        self.validate = validate if validate is not None else config.validate
+        self.validate_against_schema = (
+            validate_against_schema
+            if validate_against_schema is not None
+            else config.validate
+        )
 
     def log_(self, message, extra, log, level, fmt, trim):
         """Log a request or response"""
@@ -114,7 +122,7 @@ class Client(with_metaclass(ABCMeta, object)):
                     raise exceptions.ParseResponseError()
             # Validate the response against the Response schema (raises
             # jsonschema.ValidationError if invalid)
-            if self.validate:
+            if self.validate_against_schema:
                 self.validator.validate(response)
             if isinstance(response, list):
                 # Batch request - just return the whole response

--- a/jsonrpcclient/config.py
+++ b/jsonrpcclient/config.py
@@ -13,6 +13,3 @@ ids = "decimal"
 #: Validate responses against the JSON-RPC schema. Disable to speed up
 #: processing.
 validate = True
-
-#: Log abbreviated versions of requests and responses
-trim_log_values = False

--- a/jsonrpcclient/http_client.py
+++ b/jsonrpcclient/http_client.py
@@ -18,13 +18,12 @@ class HTTPClient(Client):
     # The default HTTP header
     DEFAULT_HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
 
-    def __init__(self, endpoint):
+    def __init__(self, *args, **kwargs):
         """
         :param endpoint: The server address.
-        :param kwargs: HTTP headers and other options passed on to the requests
-                       module.
+        :param **kwargs: Pased through to the Client class.
         """
-        super(HTTPClient, self).__init__(endpoint)
+        super(HTTPClient, self).__init__(*args, **kwargs)
         # Make use of Requests' sessions feature
         self.session = Session()
         self.session.headers.update(self.DEFAULT_HEADERS)

--- a/jsonrpcclient/request.py
+++ b/jsonrpcclient/request.py
@@ -125,17 +125,15 @@ class Request(Notification):
     :returns: The JSON-RPC request in dictionary form.
     """
 
-    id_iterator = None
+    # TODO: Replace this with a default generator (decimals).
+    id_generator = ids.from_config(config.ids)
 
-    def __init__(self, method, *args, **kwargs):
+    def __init__(self, method, *args, id_generator=None, **kwargs):
         # If 'request_id' is passed, use the specified id
         if "request_id" in kwargs:
-            _id = kwargs.pop("request_id", None)
-        else:  # Get the next id from the iterator
-            # Create the iterator if not yet created
-            if Request.id_iterator is None:
-                Request.id_iterator = ids.from_config(config.ids)
-            _id = next(self.id_iterator)
+            id_ = kwargs.pop("request_id", None)
+        else:  # Get the next id from the generator
+            id_ = next(id_generator or self.id_generator)
         # We call super last, after popping the request_id
         super(Request, self).__init__(method, *args, **kwargs)
-        self.update(id=_id)
+        self.update(id=id_)

--- a/jsonrpcclient/tornado_client.py
+++ b/jsonrpcclient/tornado_client.py
@@ -31,9 +31,9 @@ class TornadoClient(Client):
 
     DEFAULT_HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
 
-    def __init__(self, endpoint, async_http_client_class=AsyncHTTPClient, **kwargs):
-        super(TornadoClient, self).__init__(endpoint)
-        self.http_client = async_http_client_class(**kwargs)
+    def __init__(self, *args, async_http_client=None, **kwargs):
+        super(TornadoClient, self).__init__(*args, **kwargs)
+        self.http_client = async_http_client or AsyncHTTPClient()
 
     def _request_sent(self, future, response):
         """Callback when request has been sent"""

--- a/jsonrpcclient/websockets_client.py
+++ b/jsonrpcclient/websockets_client.py
@@ -7,8 +7,14 @@ from .async_client import AsyncClient
 
 
 class WebSocketsClient(AsyncClient):
-    def __init__(self, socket):
-        super(WebSocketsClient, self).__init__(None)
+    def __init__(self, socket, *args, **kwargs):
+        """
+        :param endpoint:
+        :param socket_type:
+        :param *args: Passed through to Client class.
+        :param **kwargs: Passed through to Client class.
+        """
+        super(WebSocketsClient, self).__init__(*args, **kwargs)
         self.socket = socket
 
     async def send_message(self, request, **kwargs):

--- a/jsonrpcclient/zeromq_async_client.py
+++ b/jsonrpcclient/zeromq_async_client.py
@@ -6,8 +6,14 @@ from .async_client import AsyncClient
 
 
 class ZeroMQAsyncClient(AsyncClient):
-    def __init__(self, endpoint, socket_type=zmq.REQ):
-        super(ZeroMQAsyncClient, self).__init__(endpoint)
+    """
+    :param endpoint:
+    :param socket_type:
+    :param *args: Passed through to Client class.
+    :param **kwargs: Passed through to Client class.
+    """
+    def __init__(self, endpoint, *args, socket_type=zmq.REQ, **kwargs):
+        super(ZeroMQAsyncClient, self).__init__(endpoint, *args, **kwargs)
         self.context = zmq.asyncio.Context()
         self.socket = self.context.socket(socket_type)
         self.socket.connect(endpoint)

--- a/jsonrpcclient/zeromq_client.py
+++ b/jsonrpcclient/zeromq_client.py
@@ -16,10 +16,12 @@ class ZeroMQClient(Client):
     """
     :param endpoint: The server address.
     :param socket_type: The zeromq `socket type`_. Default is *zmq.REQ*.
+    :param *args: Passed through to Client class.
+    :param **kwargs: Passed through to Client class.
     """
 
-    def __init__(self, endpoint, socket_type=zmq.REQ):
-        super(ZeroMQClient, self).__init__(endpoint)
+    def __init__(self, endpoint, *args, socket_type=zmq.REQ, **kwargs):
+        super(ZeroMQClient, self).__init__(endpoint, *args, **kwargs)
         self.context = zmq.Context()
         self.socket = self.context.socket(socket_type)
         self.socket.connect(endpoint)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,7 +20,6 @@ class DummyClient(Client):
 class TestClient(TestCase):
     def setUp(self):
         Request.id_iterator = itertools.count(1)
-        self.client = DummyClient("http://non-existant:80/")
 
     def tearDown(self):
         config.validate = True
@@ -28,8 +27,9 @@ class TestClient(TestCase):
 
 class TestLogging(TestClient):
     def test_request(self, *_):
+        client = DummyClient("foo")
         with LogCapture() as capture:
-            self.client.log_request('{"jsonrpc": "2.0", "method": "go"}')
+            client.log_request('{"jsonrpc": "2.0", "method": "go"}')
         capture.check(
             (
                 "jsonrpcclient.client.request",
@@ -39,8 +39,9 @@ class TestLogging(TestClient):
         )
 
     def test_response(self):
+        client = DummyClient("foo")
         with LogCapture() as capture:
-            self.client.log_response('{"jsonrpc": "2.0", "result": 5, "id": 1}')
+            client.log_response('{"jsonrpc": "2.0", "result": 5, "id": 1}')
         capture.check(
             (
                 "jsonrpcclient.client.response",
@@ -51,8 +52,13 @@ class TestLogging(TestClient):
 
     def test_request_trim(self):
         blahs = "blah" * 100
+        client = DummyClient("foo")
         with LogCapture() as capture:
-            self.client.log_request('{"jsonrpc": "2.0", "method": "go", "params": {"blah": "%s"}}' % (blahs,), trim=True)
+            client.log_request(
+                '{"jsonrpc": "2.0", "method": "go", "params": {"blah": "%s"}}'
+                % (blahs,),
+                trim=True,
+            )
         capture.check(
             (
                 "jsonrpcclient.client.request",
@@ -63,8 +69,11 @@ class TestLogging(TestClient):
 
     def test_response_trim(self):
         blahs = "blah" * 100
+        client = DummyClient("foo")
         with LogCapture() as capture:
-            self.client.log_response('{"jsonrpc": "2.0", "result": "%s", "id": 1}' % (blahs,), trim=True)
+            client.log_response(
+                '{"jsonrpc": "2.0", "result": "%s", "id": 1}' % (blahs,), trim=True
+            )
         capture.check(
             (
                 "jsonrpcclient.client.response",
@@ -79,91 +88,99 @@ class TestLogging(TestClient):
 
         # test string abbreviation
         message = trim_message("blah" * 100)
-        self.assertIn('...', message)
+        self.assertIn("...", message)
         # test list abbreviation
         message = trim_message(json.dumps({"list": [0] * 100}))
-        self.assertIn('...', message)
+        self.assertIn("...", message)
         # test nested abbreviation
-        message = trim_message(json.dumps({
-            "obj": {
-                "list": [0] * 100,
-                "string": "blah" * 100,
-                "obj2": {
-                    "string2": "blah" * 100,
+        message = trim_message(
+            json.dumps(
+                {
+                    "obj": {
+                        "list": [0] * 100,
+                        "string": "blah" * 100,
+                        "obj2": {"string2": "blah" * 100},
+                    }
                 }
-            }
-        }))
-        self.assertIn('...', json.loads(message)['obj']['obj2']['string2'])
+            )
+        )
+        self.assertIn("...", json.loads(message)["obj"]["obj2"]["string2"])
 
 
 class TestSend(TestClient):
     @patch("jsonrpcclient.client.Client.request_log")
     def test(self, *_):
-        self.assertEqual(
-            15, self.client.send({"jsonrpc": "2.0", "method": "out", "id": 1})
-        )
+        result = DummyClient("foo").send({"jsonrpc": "2.0", "method": "out", "id": 1})
+        self.assertEqual(result, 15)
 
 
 class TestRequest(TestClient):
     @patch("jsonrpcclient.client.Client.request_log")
     def test(self, *_):
-        self.assertEqual(15, self.client.request("multiply", 3, 5))
+        result = DummyClient("foo").request("multiply", 3, 5)
+        self.assertEqual(result, 15)
 
 
 class TestNotify(TestClient):
     @patch("jsonrpcclient.client.Client.request_log")
     def test(self, *_):
-        self.assertEqual(15, self.client.notify("multiply", 3, 5))
+        result = DummyClient("foo").notify("multiply", 3, 5)
+        self.assertEqual(result, 15)
 
 
 class TestDirect(TestClient):
     @patch("jsonrpcclient.client.Client.request_log")
     def test_alternate_usage(self, *_):
-        self.assertEqual(15, self.client.multiply(3, 5))
+        result = DummyClient("foo").multiply(3, 5)
+        self.assertEqual(result, 15)
 
 
 class TestProcessResponse(TestClient):
     @patch("jsonrpcclient.client.Client.request_log")
     def test_none(self, *_):
-        response = None
-        self.assertEqual(None, self.client.process_response(response))
+        result = DummyClient("foo").process_response(None)
+        self.assertEqual(result, None)
 
     def test_empty_string(self):
-        response = ""
-        self.assertEqual(None, self.client.process_response(response))
+        result = DummyClient("foo").process_response("")
+        self.assertEqual(result, None)
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_valid_json(self, *_):
-        response = {"jsonrpc": "2.0", "result": 5, "id": 1}
-        self.assertEqual(5, self.client.process_response(response))
+        result = DummyClient("foo").process_response(
+            {"jsonrpc": "2.0", "result": 5, "id": 1}
+        )
+        self.assertEqual(result, 5)
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_valid_json_null_id(self, *_):
-        response = {"jsonrpc": "2.0", "result": 5, "id": None}
-        self.assertEqual(5, self.client.process_response(response))
+        result = DummyClient("foo").process_response(
+            {"jsonrpc": "2.0", "result": 5, "id": None}
+        )
+        self.assertEqual(result, 5)
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_valid_string(self, *_):
-        response = '{"jsonrpc": "2.0", "result": 5, "id": 1}'
-        self.assertEqual(5, self.client.process_response(response))
+        result = DummyClient("foo").process_response(
+            '{"jsonrpc": "2.0", "result": 5, "id": 1}'
+        )
+        self.assertEqual(result, 5)
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_invalid_json(self, *_):
-        response = "{dodgy}"
         with self.assertRaises(exceptions.ParseResponseError):
-            self.client.process_response(response)
+            DummyClient("foo").process_response("{dodgy}")
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_invalid_jsonrpc(self, *_):
-        response = {"json": "2.0"}
         with self.assertRaises(ValidationError):
-            self.client.process_response(response)
+            DummyClient("foo").process_response({"json": "2.0"})
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_without_validation(self, *_):
         config.validate = False
-        response = {"json": "2.0"}
-        self.client.process_response(response)
+        # Should not raise exception
+        DummyClient("foo").process_response({"json": "2.0"})
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_error_response(self, *_):
@@ -173,7 +190,7 @@ class TestProcessResponse(TestClient):
             "id": None,
         }
         with self.assertRaises(exceptions.ReceivedErrorResponse) as ex:
-            self.client.process_response(response)
+            DummyClient("foo").process_response(response)
         self.assertEqual(ex.exception.code, -32000)
         self.assertEqual(ex.exception.message, "Not Found")
         self.assertEqual(ex.exception.data, None)
@@ -190,7 +207,7 @@ class TestProcessResponse(TestClient):
             "id": None,
         }
         with self.assertRaises(exceptions.ReceivedErrorResponse) as ex:
-            self.client.process_response(response)
+            DummyClient("foo").process_response(response)
         self.assertEqual(ex.exception.code, -32000)
         self.assertEqual(ex.exception.message, "Not Found")
         self.assertEqual(
@@ -206,7 +223,7 @@ class TestProcessResponse(TestClient):
             "id": None,
         }
         with self.assertRaises(exceptions.ReceivedErrorResponse) as ex:
-            self.client.process_response(response)
+            DummyClient("foo").process_response(response)
         self.assertEqual(ex.exception.code, -32000)
         self.assertEqual(ex.exception.message, "Not Found")
         self.assertEqual(ex.exception.data, {})
@@ -222,7 +239,8 @@ class TestProcessResponse(TestClient):
                 "id": 3,
             },
         ]
-        self.assertEqual(response, self.client.process_response(response))
+        result = DummyClient("foo").process_response(response)
+        self.assertEqual(result, response)
 
     @patch("jsonrpcclient.client.Client.response_log")
     def test_batch_string(self, *_):
@@ -232,4 +250,5 @@ class TestProcessResponse(TestClient):
             '{"jsonrpc": "2.0", "result": null, "id": 2},'
             '{"jsonrpc": "2.0", "error": {"code": -32000, "message": "Not Found"}, "id": 3}]'
         )
-        self.assertEqual(json.loads(response), self.client.process_response(response))
+        result = DummyClient("foo").process_response(response)
+        self.assertEqual(result, json.loads(response))

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -12,8 +12,8 @@ from jsonrpcclient.http_client import HTTPClient
 
 class TestHTTPClient(TestCase):
     def setUp(self):
-        # Patch Request.id_iterator to ensure the id is always 1
-        Request.id_iterator = itertools.count(1)
+        # Patch Request.id_generator to ensure the id is always 1
+        Request.id_generator = itertools.count(1)
 
     @staticmethod
     def test_init_endpoint_only():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,92 @@
+from unittest import TestCase
+from unittest.mock import patch
+from testfixtures import LogCapture, StringComparison
+from collections import namedtuple
+
+from jsonrpcclient import request, notify, ids
+
+
+Resp = namedtuple("Response", ("text", "reason", "headers", "status_code"))
+
+
+class TestRequest(TestCase):
+    @patch("jsonrpcclient.client.Client.request_log")
+    @patch("jsonrpcclient.HTTPClient.send_message", return_value="bar")
+    def test(self, *_):
+        result = request("http://foo", "foo")
+        self.assertEqual(result, "bar")
+
+    @patch("jsonrpcclient.client.Client.response_log")
+    @patch(
+        "jsonrpcclient.http_client.Session.send",
+        return_value=Resp(
+            text='{"jsonrpc": "2.0", "result": true, "id": 1}',
+            reason="foo",
+            headers="foo",
+            status_code=200,
+        ),
+    )
+    def test_trim_log_values(self, *_):
+        with LogCapture() as capture:
+            request(
+                "http://foo",
+                "foo",
+                blah="blah" * 100,
+                request_id=1,
+                trim_log_values=True,
+            )
+        capture.check(
+            (
+                "jsonrpcclient.client.request",
+                "INFO",
+                '{"jsonrpc": "2.0", "method": "foo", "params": {"blah": "blahblahbl...ahblahblah"}, "id": 1}',
+            )
+        )
+
+    @patch("jsonrpcclient.client.Client.response_log")
+    @patch(
+        "jsonrpcclient.http_client.Session.send",
+        return_value=Resp(
+            text='{"jsonrpc": "2.0", "result": true, "id": 1}',
+            reason="foo",
+            headers="foo",
+            status_code=200,
+        ),
+    )
+    def test_id_generator(self, *_):
+        # Set id type in config to decimal
+        import jsonrpcclient.config
+        jsonrpcclient.config.ids = "decimal"
+        with LogCapture() as capture:
+            result = request("http://foo", "foo", id_generator=ids.random())
+        capture.check(
+            (
+                "jsonrpcclient.client.request",
+                "INFO",
+                StringComparison(r'{"jsonrpc": "2.0", "method": "foo", "id": "[a-z0-9]{8}"')
+            )
+        )
+
+
+class TestNotify(TestCase):
+    @patch("jsonrpcclient.client.Client.request_log")
+    @patch("jsonrpcclient.HTTPClient.send_message", return_value="bar")
+    def test(self, *_):
+        result = notify("http://foo", "foo")
+        self.assertEqual(result, "bar")
+
+    @patch("jsonrpcclient.client.Client.response_log")
+    @patch(
+        "jsonrpcclient.http_client.Session.send",
+        return_value=Resp(text="", reason="foo", headers="foo", status_code=200),
+    )
+    def test_trim_log_values(self, *_):
+        with LogCapture() as capture:
+            notify("http://foo", "foo", blah="blah" * 100, trim_log_values=True)
+        capture.check(
+            (
+                "jsonrpcclient.client.request",
+                "INFO",
+                '{"jsonrpc": "2.0", "method": "foo", "params": {"blah": "blahblahbl...ahblahblah"}}',
+            )
+        )

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import json
 
 from jsonrpcclient.request import Notification, Request, sort_request
+from jsonrpcclient import ids
 from jsonrpcclient import config
 
 
@@ -50,12 +51,12 @@ class TestNotification(TestCase):
 class TestRequest(TestCase):
     def setUp(self):
         # Start each test with id 1
-        Request.id_iterator = None
+        Request.id_generator = ids.decimal()
         config.ids = "decimal"
 
     def tearDown(self):
         # Restore default iterator
-        Request.id_iterator = None
+        Request.id_generator = ids.decimal()
         config.ids = "decimal"
 
     def test(self):
@@ -93,5 +94,6 @@ class TestRequest(TestCase):
 
     def test_custom_iterator(self):
         config.ids = "random"
+        Request.id_generator = ids.random()
         req = Request("go")
         self.assertEqual(8, len(req["id"]))

--- a/tests/test_tornado_client.py
+++ b/tests/test_tornado_client.py
@@ -37,8 +37,8 @@ class TestTornadoClient(testing.AsyncHTTPTestCase):
 
     def setUp(self):
         super(TestTornadoClient, self).setUp()
-        # Patch Request.id_iterator to ensure the id is always 1
-        Request.id_iterator = itertools.count(1)
+        # Patch Request.id_generator to ensure the id is always 1
+        Request.id_generator = itertools.count(1)
 
     @patch("jsonrpcclient.client.Client.request_log")
     @patch("jsonrpcclient.client.Client.response_log")

--- a/tests/test_zmq_client.py
+++ b/tests/test_zmq_client.py
@@ -11,8 +11,8 @@ from jsonrpcclient.zmq_client import ZMQClient
 
 class TestZMQClient(TestCase):
     def setUp(self):
-        # Patch Request.id_iterator to ensure the request id is always 1
-        Request.id_iterator = itertools.count(1)
+        # Patch Request.id_generator to ensure the request id is always 1
+        Request.id_generator = itertools.count(1)
 
     def test_instantiate(self):
         ZMQClient("tcp://localhost:5555")


### PR DESCRIPTION
Instead of the config module, pass configuration options as parameter values.

Client example:
```python
from jsonrpcclient.http_client import HTTPClient
client = HTTPClient("http://example.com", trim_log_values=True)
client.request("ping")
```

Convenience example:

```python
from jsonrpcclient import request
request("http://example.com", "ping", trim_log_values=True)
```

The other options are `validate` and `id_generator`.