### PR TITLE
Exposing access to aiohttp request() ssl parameter

### DIFF
--- a/jsonrpcclient/clients/aiohttp_client.py
+++ b/jsonrpcclient/clients/aiohttp_client.py
@@ -19,11 +19,12 @@ class AiohttpClient(AsyncClient):
     DEFAULT_RESPONSE_LOG_FORMAT = "<-- %(message)s (%(http_code)s %(http_reason)s)"
 
     def __init__(
-        self, session: ClientSession, endpoint: str, *args: Any, **kwargs: Any
+        self, session: ClientSession, endpoint: str, *args: Any, ssl=None, **kwargs: Any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.endpoint = endpoint
         self.session = session
+        self.ssl = ssl
 
     def log_response(
         self, response: Response, trim_log_values: bool = False, **kwargs: Any
@@ -43,6 +44,6 @@ class AiohttpClient(AsyncClient):
 
     async def send_message(self, request: str) -> Response:  # type: ignore
         with async_timeout.timeout(10):
-            async with self.session.post(self.endpoint, data=request) as response:
+            async with self.session.post(self.endpoint, data=request, ssl=self.ssl) as response:
                 response_text = await response.text()
                 return Response(response_text, raw=response)


### PR DESCRIPTION
A possible way to pass an SSLContext / SSL verification preferences to the actual aiohttp request. A possible fix for #93 