### PR TITLE
response.data should never be None

### DIFF
--- a/jsonrpcclient/async_client.py
+++ b/jsonrpcclient/async_client.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 
 from apply_defaults import apply_self  # type: ignore
 
-from .client import Client
+from .client import Client, is_batch_request
 from .parse import parse
 from .request import Notification, Request
 from .response import Response
@@ -42,7 +42,9 @@ class AsyncClient(Client, metaclass=ABCMeta):
         self.log_response(response, trim_log_values=trim_log_values)
         self.validate_response(response)
         response.data = parse(
-            response.text, validate_against_schema=validate_against_schema
+            response.text,
+            batch=is_batch_request(request_text),
+            validate_against_schema=validate_against_schema,
         )
         return response
 

--- a/jsonrpcclient/exceptions.py
+++ b/jsonrpcclient/exceptions.py
@@ -1,8 +1,7 @@
 """
 Exceptions.
 
-These exceptions are raised when processing responses from the server. For example, if
-the response was garbage and could not be parsed, `ParseResponseError` is raised.
+These exceptions are raised when processing responses from the server.
 
 To handle them, use a try-block when calling send/request/notify:
 
@@ -11,6 +10,7 @@ To handle them, use a try-block when calling send/request/notify:
     except JsonRpcClientError as e:
         ...
 """
+from jsonrpcclient.response import JSONRPCResponse
 
 
 class JsonRpcClientError(Exception):
@@ -19,16 +19,17 @@ class JsonRpcClientError(Exception):
     pass
 
 
-class ParseResponseError(JsonRpcClientError):
-    """The response was not valid JSON."""
-
-    def __init__(self) -> None:
-        super().__init__("The response was not valid JSON")
-
-
 class ReceivedNon2xxResponseError(JsonRpcClientError):
     """The response was not valid JSON."""
 
     def __init__(self, status_code: int) -> None:
         super().__init__("Received {} status code".format(status_code))
         self.code = status_code
+
+
+class ReceivedErrorResponseError(JsonRpcClientError):
+    """The response was an error response."""
+
+    def __init__(self, response: JSONRPCResponse) -> None:
+        super().__init__("Received error response: {response.message}")
+        self.response = response

--- a/jsonrpcclient/exceptions.py
+++ b/jsonrpcclient/exceptions.py
@@ -31,5 +31,5 @@ class ReceivedErrorResponseError(JsonRpcClientError):
     """The response was an error response."""
 
     def __init__(self, response: JSONRPCResponse) -> None:
-        super().__init__("Received error response: {response.message}")
+        super().__init__(response.message)
         self.response = response

--- a/jsonrpcclient/parse.py
+++ b/jsonrpcclient/parse.py
@@ -54,4 +54,4 @@ def parse(
     if isinstance(deserialized, list):
         return [JSONRPCResponse(r) for r in deserialized if "id" in r]
     # Single request
-    return JSONRPCResponse(deserialized) if "id" in deserialized else None
+    return JSONRPCResponse(deserialized if "id" in deserialized else None)

--- a/jsonrpcclient/parse.py
+++ b/jsonrpcclient/parse.py
@@ -54,4 +54,4 @@ def parse(
     if isinstance(deserialized, list):
         return [JSONRPCResponse(r) for r in deserialized if "id" in r]
     # Single request
-    return JSONRPCResponse(deserialized if "id" in deserialized else None)
+    return JSONRPCResponse(deserialized)

--- a/jsonrpcclient/parse.py
+++ b/jsonrpcclient/parse.py
@@ -2,12 +2,11 @@
 Parse response text, returning JSONRPCResponse objects.
 """
 from typing import List, Union
-from json import loads as deserialize, JSONDecodeError
+from json import loads as deserialize
 
 import jsonschema  # type: ignore
 from pkg_resources import resource_string
 
-from . import exceptions
 from .response import JSONRPCResponse
 
 schema = deserialize(resource_string(__name__, "response-schema.json").decode())

--- a/jsonrpcclient/parse.py
+++ b/jsonrpcclient/parse.py
@@ -1,8 +1,8 @@
 """
 Parse response text, returning JSONRPCResponse objects.
 """
-import json
 from typing import List, Union
+from json import loads as deserialize, JSONDecodeError
 
 import jsonschema  # type: ignore
 from pkg_resources import resource_string
@@ -10,36 +10,48 @@ from pkg_resources import resource_string
 from . import exceptions
 from .response import JSONRPCResponse
 
-response_schema = json.loads(resource_string(__name__, "response-schema.json").decode())
+schema = deserialize(resource_string(__name__, "response-schema.json").decode())
 
 
 def parse(
-    response_text: str, validate_against_schema: bool = True
-) -> Union[JSONRPCResponse, List[JSONRPCResponse], None]:
+    response_text: str, *, batch: bool, validate_against_schema: bool = True
+) -> Union[JSONRPCResponse, List[JSONRPCResponse]]:
     """
     Parses response text, returning JSONRPCResponse objects.
 
     Args:
         response_text: JSON-RPC response string.
-        ParseResponseError: The response was not valid JSON.
-        ValidationError: The response was not a valid JSON-RPC response object.
-    """
-    if response_text:
-        # If a string, ensure it's json-decodable
-        try:
-            decoded = json.loads(response_text)
-        except ValueError:
-            raise exceptions.ParseResponseError()
-        # Validate the response against the Response schema (raises
-        # jsonschema.ValidationError if invalid)
-        if validate_against_schema:
-            jsonschema.validate(decoded, response_schema)
+        is_batch_request: If the response_text is an empty string, this determines how
+            to parse.
+        validate_against_schema: Validate against the json-rpc schema.
 
-        # Return a Response object, or a list of Responses in the case of a batch
-        # request.
-        if isinstance(decoded, list):
-            return [JSONRPCResponse(r) for r in decoded if "id" in r]
-        # else:
-        return JSONRPCResponse(decoded) if "id" in decoded else None
-    # else:
-    return None
+    Returns:
+        Either a JSONRPCResponse, or a list of them.
+
+    Raises:
+        json.JSONDecodeError: The response was not valid JSON.
+        jsonschema.ValidationError: The response was not a valid JSON-RPC response
+            object.
+    """
+    # If the response is empty, we can't deserialize it. The return value depends on if
+    # it's responding to a batch request or not.
+    if not response_text:
+        if batch:
+            # An empty string is a valid response to a batch request, when there were
+            # only notifications in the batch.
+            return []
+        else:
+            # An empty string is valid response to a Notification request.
+            return JSONRPCResponse(None)
+
+    # If a string, ensure it's json-deserializable
+    deserialized = deserialize(response_text)
+    # Validate the response against the Response schema (raises
+    # jsonschema.ValidationError if invalid)
+    if validate_against_schema:
+        jsonschema.validate(deserialized, schema)
+    # Batch
+    if isinstance(deserialized, list):
+        return [JSONRPCResponse(r) for r in deserialized if "id" in r]
+    # Single request
+    return JSONRPCResponse(deserialized) if "id" in deserialized else None

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,11 +3,6 @@ import pytest
 from jsonrpcclient import exceptions
 
 
-def test_parse_response_error():
-    with pytest.raises(exceptions.ParseResponseError):
-        raise exceptions.ParseResponseError
-
-
 def test_non_2xx_status_code_error():
     with pytest.raises(exceptions.ReceivedNon2xxResponseError):
         raise exceptions.ReceivedNon2xxResponseError(404)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
+from json import JSONDecodeError
 
 from click.testing import CliRunner
 
 from jsonrpcclient.__main__ import main
-from jsonrpcclient.exceptions import ParseResponseError
 
 
 def test():
@@ -22,7 +22,7 @@ def test_send(*_):
     assert result.exit_code == 0
 
 
-@patch("jsonrpcclient.__main__.HTTPClient.send", side_effect=ParseResponseError)
+@patch("jsonrpcclient.__main__.HTTPClient.send", side_effect=JSONDecodeError)
 def test_send_error(*_):
     result = CliRunner().invoke(main, ["foo", "--send=http://foo"])
-    assert result.exit_code > 0
+    assert result.exit_code == -1

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,7 +1,7 @@
 import pytest
 from jsonschema import ValidationError
+from json import JSONDecodeError
 
-from jsonrpcclient import exceptions
 from jsonrpcclient.parse import JSONRPCResponse, parse
 
 
@@ -24,6 +24,7 @@ class TestJSONRPCResponse:
         assert response.id == None
 
     def test_none(self, *_):
+        """Really shouldn't be passing None into parse. Takes a string."""
         response = JSONRPCResponse(None)
         # Is an acceptable response.
         assert response.ok == True
@@ -87,35 +88,39 @@ class TestParse:
     """
 
     def test(self, *_):
-        parse('{"jsonrpc": "2.0", "result": "foo", "id": 1}')
+        parse('{"jsonrpc": "2.0", "result": "foo", "id": 1}', batch=False)
 
     def test_invalid_json(self, *_):
-        with pytest.raises(exceptions.ParseResponseError):
-            parse("{dodgy}")
+        with pytest.raises(JSONDecodeError):
+            parse("{dodgy}", batch=False)
 
     def test_invalid_jsonrpc(self, *_):
         with pytest.raises(ValidationError):
-            parse('{"json": "2.0"}')
+            parse('{"json": "2.0"}', batch=False)
 
     def test_without_validation(self, *_):
         parse(
             '{"jsonrpc": "2.0", "result": "foo", "id": 1}',
+            batch=False,
             validate_against_schema=False,
         )
 
     def test_batch(self, *_):
-        data = parse('[{"jsonrpc": "2.0", "result": "foo", "id": 1}]')
+        data = parse('[{"jsonrpc": "2.0", "result": "foo", "id": 1}]', batch=True)
         assert data[0].result == "foo"
 
     def test_batch_ignores_notifications(self, *_):
-        data = parse('[{"jsonrpc": "2.0", "result": "foo", "id": 1}]')
+        data = parse('[{"jsonrpc": "2.0", "result": "foo", "id": 1}]', batch=True)
         assert len(data) == 1
 
-    def test_empty_string(self, *_):
-        assert parse("") is None
+    def test_empty_string_single(self, *_):
+        assert parse("", batch=False).result is None
 
-    def test_none(self, *_):
-        assert parse(None) is None
+    def test_empty_string_batch(self, *_):
+        assert parse("", batch=True) == []
 
-    def test_empty_string(self, *_):
-        assert parse("") is None
+    def test_none_single(self, *_):
+        assert parse(None, batch=False).result is None
+
+    def test_none_batch(self, *_):
+        assert parse(None, batch=True) == []


### PR DESCRIPTION
Ensures that response.data is always a JSONRPCReponse, or a list of them in the case of batch requests.

It will never be `None`.

Closes #98 