### PR TITLE
Fix unexpected behavior when passing one argument

### DIFF
--- a/jsonrpcclient/requests.py
+++ b/jsonrpcclient/requests.py
@@ -89,22 +89,20 @@ class Notification(dict, metaclass=_RequestClassType):  # type: ignore
 
     def __init__(self, method: str, *args: Any, **kwargs: Any) -> None:
         super().__init__(jsonrpc="2.0", method=method)
-        # Build the 'params' part. Merge the positional and keyword arguments into one
-        # list.
-        params_list = []  # type: List
-        if args:
-            params_list.extend(args)
-        if kwargs:
-            params_list.append(kwargs)
         # Add the params to self.
-        if params_list:
-            # The 'params' can be either "by-position" (a list) or "by-name" (a dict).
-            # If there's only one list or dict in the params list, take it out of the
-            # enclosing list, ie. [] instead of [[]], {} instead of [{}].
-            if len(params_list) == 1 and (isinstance(params_list[0], (dict, list))):
-                self.update(params=params_list[0])
-            else:
-                self.update(params=params_list)
+        if args and kwargs:
+            # The 'params' can be *EITHER* "by-position" (a list) or "by-name" (a dict).
+            # Therefore, in this case it violates the JSON-RPC 2.0 specification.  However,
+            # it provides the same behavior as the previous version of jsonrpcclient to
+            # keep compatibility.
+            # TODO: consider to raise a warning.
+            params_list = list(args)
+            params_list.append(kwargs)
+            self.update(params=params_list)
+        elif args:
+            self.update(params=list(args))
+        elif kwargs:
+            self.update(params=kwargs)
 
     def __str__(self) -> str:
         """Wrapper around request, returning a string instead of a dict"""

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -32,6 +32,16 @@ class TestNotification:
             "method": "sqrt",
             "params": [1],
         }
+        assert Notification("sqrt", [1, 2, 3]) == {
+            "jsonrpc": "2.0",
+            "method": "sqrt",
+            "params": [[1, 2, 3]],
+        }
+        assert Notification("sqrt", {"name": "Foo"}) == {
+            "jsonrpc": "2.0",
+            "method": "sqrt",
+            "params": [{"name": "Foo"}],
+        }
 
     def test_keyword(self):
         assert Notification("find", name="Foo") == {
@@ -68,6 +78,18 @@ class TestRequest:
             "method": "sqrt",
             "params": [1],
             "id": 1,
+        }
+        assert Request("sqrt", [1, 2, 3]) == {
+            "jsonrpc": "2.0",
+            "method": "sqrt",
+            "params": [[1, 2, 3]],
+            "id": 2,
+        }
+        assert Request("sqrt", {"name": "Foo"}) == {
+            "jsonrpc": "2.0",
+            "method": "sqrt",
+            "params": [{"name": "Foo"}],
+            "id": 3,
         }
 
     def test_keyword(self):


### PR DESCRIPTION
When passing one positional argument of list:

```
>>> tags = ['a', 'b', 'c']
>>> jsonrpcclient.requests.Request('add_tags', tags)
The expected result:
  {'jsonrpc': '2.0', 'method': 'add_tags', 'params': [['a', 'b', 'c']], 'id': 1}.
The actual result:
  {'jsonrpc': '2.0', 'method': 'add_tags', 'params': ['a', 'b', 'c'], 'id': 1}
```

When passing one positional argument of dict:

```
>>> items = {'foo': 100, 'bar': 200}
>>> jsonrpcclient.requests.Request('add_items', items)
The expected result:
  {'jsonrpc': '2.0', 'method': 'add_items', 'params': [{'foo': 100, 'bar': 200}], 'id': 1}
The actual result:
  {'jsonrpc': '2.0', 'method': 'add_items', 'params': {'foo': 100, 'bar': 200}, 'id': 1}
```