### PR TITLE
Make py.typed visible to mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,10 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     name="jsonrpcclient",
+    # Be PEP 561 compliant
+    # https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages
     package_data={"jsonrpcclient": ["response-schema.json", "py.typed"]},
+    zip_safe=False,
     packages=["jsonrpcclient", "jsonrpcclient.clients"],
     url="https://github.com/bcb/jsonrpcclient",
     version="3.3.4",


### PR DESCRIPTION
Apparently, if you use setuptools and include a `py.typed` file, you need to add `zip_safe=False` to `setup()` in `setup.py` or else mypy can't find it. Who knew! (https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages)

I'm also opening a PR for [jsonrpcserver](https://github.com/bcb/jsonrpcserver).