### PR TITLE
Pass **kwargs to AiohttpClient from client.send() call

### DIFF
--- a/jsonrpcclient/clients/aiohttp_client.py
+++ b/jsonrpcclient/clients/aiohttp_client.py
@@ -65,7 +65,7 @@ class AiohttpClient(AsyncClient):
         """
         with async_timeout.timeout(self.timeout):
             async with self.session.post(
-                self.endpoint, data=request, ssl=self.ssl
+                self.endpoint, data=request, ssl=self.ssl, **kwargs
             ) as response:
                 response_text = await response.text()
                 return Response(response_text, raw=response)


### PR DESCRIPTION
According to docs you may pass extra params for request in `client.send()` method.

But these values are not proxied to aiohttp-client `.post()` method