### PR TITLE
Accept click version 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "zmq": ["pyzmq"],
     },
     include_package_data=True,
-    install_requires=["apply_defaults<1", "click<7", "jsonschema<4"],
+    install_requires=["apply_defaults<1", "click<8", "jsonschema<4"],
     license="MIT",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -40,5 +40,5 @@ setup(
     zip_safe=False,
     packages=["jsonrpcclient", "jsonrpcclient.clients"],
     url="https://github.com/bcb/jsonrpcclient",
-    version="3.3.5",
+    version="3.3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     zip_safe=False,
     packages=["jsonrpcclient", "jsonrpcclient.clients"],
     url="https://github.com/bcb/jsonrpcclient",
-    version="3.3.6",
+    version="3.3.5",
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 from json import JSONDecodeError
 from unittest.mock import patch
 
+import click
 from click.testing import CliRunner
 
 from jsonrpcclient.__main__ import main
@@ -22,7 +23,16 @@ def test_send(*_):
     assert result.exit_code == 0
 
 
+def get_click_exception_return_code():
+    # The reason for this is that in click 7.0 the return code for an Exception changed
+    # from -1 to 1
+    click_version_major = int(click.__version__.split(sep='.')[0])
+    if click_version_major < 7:
+        return -1
+    return 1
+
+
 @patch("jsonrpcclient.__main__.HTTPClient.send", side_effect=JSONDecodeError)
 def test_send_error(*_):
     result = CliRunner().invoke(main, ["foo", "--send=http://foo"])
-    assert result.exit_code == -1
+    assert result.exit_code == get_click_exception_return_code()


### PR DESCRIPTION
The current version of click is 7.1, to avoid conflicts with other packages that require click>=7, the click requirement could be changed to accept newer version.

The effect of using click version 7 (instead of 6) is that the exit value of when an exception is encountered changed from -1 to 1 (when using the click based CLI for jsonrpcclient)

Closes #146