### PR TITLE
Ensure py.typed file is included in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include README.md CHANGELOG.md jsonrpcclient/response-schema.json LICENSE
+include README.md CHANGELOG.md LICENSE
+include jsonrpcclient/py.typed jsonrpcclient/response-schema.json


### PR DESCRIPTION
This is same as bcb/jsonrpcserver#159.