### PR TITLE
fix test when jsonrpcclient is not installed

### DIFF
--- a/jsonrpcclient/__main__.py
+++ b/jsonrpcclient/__main__.py
@@ -21,7 +21,13 @@ from jsonrpcclient.clients.http_client import HTTPClient
 from jsonrpcclient.exceptions import JsonRpcClientError
 from jsonrpcclient.requests import Notification, Request
 
-version = pkg_resources.require("jsonrpcclient")[0].version
+try:
+    version = pkg_resources.require("jsonrpcclient")[0].version
+except pkg_resources.DistributionNotFound:
+    # pkg_resources (and importlib) can struggle to find module resource
+    # information when the package isn't installed in typical locations (such as
+    # testing during a package build).
+    version = 'unknown'
 
 
 @click.command(


### PR DESCRIPTION
When building a Debian package for jsonrpcclient, all tests succeed except for `tests/test_main.py`. `import jsonrpcclient` discovers the module in the build directory just fine. `pkg_resources`, however, does not find it.

This is not the most elegant fix, but my efforts to use `importlib` were unsuccessful.

The relavent section of the output.

```
I: pybuild base:232: cd /home/aqw/git/inm7/packaging/python-json-rpc-client/.pybuild/cpython3_3.9_python3-json-rpc-client/build; python3.9 -m pytest tests
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/aqw/git/inm7/packaging/python-json-rpc-client
plugins: asyncio-0.14.0
collected 80 items / 1 error / 79 selected

==================================== ERRORS ====================================
_ ERROR collecting .pybuild/cpython3_3.9_python3-json-rpc-client/build/tests/test_main.py _
tests/test_main.py:7: in <module>
    from jsonrpcclient.__main__ import main
jsonrpcclient/__main__.py:23: in <module>
    version = pkg_resources.require("jsonrpcclient")[0].version
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:886: in require
    needed = self.resolve(parse_requirements(requirements))
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:772: in resolve
    raise DistributionNotFound(req, requirers)
E   pkg_resources.DistributionNotFound: The 'jsonrpcclient' distribution was not found and is required by the application
=========================== short test summary info ============================
ERROR tests/test_main.py - pkg_resources.DistributionNotFound: The 'jsonrpccl...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.37s ===============================
E: pybuild pybuild:353: test: plugin distutils failed with: exit code=2: cd /home/aqw/git/inm7/packaging/python-json-rpc-client/.pybuild/cpython3_3.9_python3-json-rpc-client/build; python3.9 -m pytest tests
dh_auto_test: error: pybuild --test --test-pytest -i python{version} -p 3.9 returned exit code 13
make: *** [debian/rules:7: build] Error 25
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -i -I failed
```